### PR TITLE
remove stale SPI placeholder text and add explicit wiring links

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -13,7 +13,7 @@ This repo keeps UI-specific documentation only. Shared architecture/product docs
 
 ## UI-Specific Extension Points
 
-Add UI-owned docs in this folder for:
+UI-owned docs in this folder cover:
 
 - MVU state shape and actions
 - Update loop and effect handling

--- a/docs/SPI.md
+++ b/docs/SPI.md
@@ -4,4 +4,7 @@ Canonical SPI spec lives in `friction-core`:
 
 - [friction-core/docs/SPI.md](https://github.com/idelstak/friction-core/blob/master/docs/SPI.md)
 
-UI-specific notes for consuming SPI outputs should be documented in this repo when introduced.
+UI-specific SPI consumption and effects wiring are documented here:
+
+- [SPI Consumption and Effects Wiring](./SPI_EFFECTS_WIRING.md)
+- [MVU Conventions](./MVU_CONVENTIONS.md)


### PR DESCRIPTION
- Updated `docs/SPI.md` to remove stale "when introduced" placeholder wording.
- Added explicit direct links from `docs/SPI.md` to:
  - `docs/SPI_EFFECTS_WIRING.md`
  - `docs/MVU_CONVENTIONS.md`
- Tightened `docs/README.md` wording in the UI extension section to reflect current docs state.
- Keeps canonical SPI contract in `friction-core` while clarifying UI-local SPI/effects documentation.