### PR TITLE
add local GitHub Actions preflight script and workflow guide

### DIFF
--- a/docs/WORKFLOW_DEV.md
+++ b/docs/WORKFLOW_DEV.md
@@ -1,0 +1,70 @@
+# Workflow Development and Local Preflight
+
+Use this guide to validate GitHub Actions workflows locally before pushing.
+
+## Required Tools
+
+- `actionlint`
+- `yamllint`
+- `act`
+
+## Installation
+
+### Arch Linux (`pacman`)
+
+```bash
+sudo pacman -S --needed actionlint yamllint act
+```
+
+### actionlint
+
+- Project: `https://github.com/rhysd/actionlint`
+- Example (Go): `go install github.com/rhysd/actionlint/cmd/actionlint@latest`
+
+### yamllint
+
+- Example (pipx): `pipx install yamllint`
+- Alternative: `pip install yamllint`
+
+### act
+
+- Project: `https://github.com/nektos/act`
+- Install using package manager or official release binary
+
+## Run Local Preflight
+
+From repo root:
+
+```bash
+scripts/check-workflows.sh
+```
+
+What it does:
+
+1. Verifies required tools are installed.
+2. Runs `actionlint`.
+3. Runs `yamllint .github/workflows`.
+4. Runs `act` dry-run smoke checks for key workflows if present:
+   - `ci.yml`
+   - `release.yml`
+   - `publish-ui.yml`
+
+## `act` Limitations for Cross-Platform `jpackage`
+
+`friction-ui` releases are expected to package cross-platform artifacts with `jpackage` on Linux, macOS, and Windows runners.
+
+Local `act` caveats:
+
+- `act` runs in local containerized context and may not match GitHub-hosted OS environments exactly.
+- Cross-platform `jpackage` packaging cannot be fully validated in one local environment.
+- Use `act` as workflow wiring smoke test, not final packaging parity proof.
+
+Recommended practice:
+
+- Validate workflow structure locally with `actionlint` + `yamllint` + `act` dry-run.
+- Validate real packaging behavior with at least one GitHub-hosted run per target platform.
+
+## Notes
+
+- Script is non-destructive and fast-fails on first error.
+- If `.github/workflows` does not exist yet, script exits successfully with a skip message.

--- a/scripts/check-workflows.sh
+++ b/scripts/check-workflows.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+WORKFLOW_DIR="$ROOT_DIR/.github/workflows"
+
+require_cmd() {
+  local cmd="$1"
+  local install_hint="$2"
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    echo "ERROR: Missing required command: $cmd"
+    echo "Install hint: $install_hint"
+    exit 1
+  fi
+}
+
+print_step() {
+  echo
+  echo "==> $1"
+}
+
+print_step "Validating local tooling"
+require_cmd "actionlint" "https://github.com/rhysd/actionlint"
+require_cmd "yamllint" "pipx install yamllint (or pip install yamllint)"
+require_cmd "act" "https://github.com/nektos/act"
+
+if [[ ! -d "$WORKFLOW_DIR" ]]; then
+  echo "No workflow directory found at $WORKFLOW_DIR"
+  echo "Nothing to validate yet"
+  exit 0
+fi
+
+print_step "Running actionlint"
+(
+  cd "$ROOT_DIR"
+  actionlint
+)
+
+print_step "Running yamllint on workflow files"
+(
+  cd "$ROOT_DIR"
+  yamllint .github/workflows
+)
+
+print_step "Running act dry-run smoke checks for key workflows"
+KEY_WORKFLOWS=("ci.yml" "release.yml" "publish-ui.yml")
+FOUND=0
+
+for wf in "${KEY_WORKFLOWS[@]}"; do
+  full_path="$WORKFLOW_DIR/$wf"
+  if [[ -f "$full_path" ]]; then
+    FOUND=1
+    echo "Dry-run: $wf"
+    (
+      cd "$ROOT_DIR"
+      act -n pull_request -W ".github/workflows/$wf"
+    )
+  fi
+done
+
+if [[ "$FOUND" -eq 0 ]]; then
+  echo "No key workflows found (${KEY_WORKFLOWS[*]}); skipping act smoke checks"
+fi
+
+echo
+echo "Workflow preflight checks passed"


### PR DESCRIPTION
- Added local workflow preflight script: `scripts/check-workflows.sh`.
- Script validates workflow quality locally by running:
  - `actionlint`
  - `yamllint .github/workflows`
  - `act` dry-run smoke checks for key workflows if present (`ci.yml`, `release.yml`, `publish-ui.yml`)
- Script is non-destructive, fast-fail, and gracefully skips when no workflow directory exists yet.
- Added `docs/WORKFLOW_DEV.md` with install and usage instructions for:
  - `actionlint`
  - `yamllint`
  - `act`
- Included Arch Linux `pacman` install command.
- Added explicit notes on `act` limitations for cross-platform `jpackage` workflows and recommended GitHub-hosted parity checks.