### PR TITLE
Automate UI release and cross-platform packaging

### DIFF
--- a/.github/workflows/publish-ui.yml
+++ b/.github/workflows/publish-ui.yml
@@ -1,0 +1,221 @@
+---
+name: Publish UI Artifacts
+
+'on':
+  workflow_run:
+    workflows:
+      - Release
+    types:
+      - completed
+
+permissions:
+  contents: write
+  packages: read
+
+concurrency:
+  group: publish-ui-master
+  cancel-in-progress: false
+
+jobs:
+  prepare:
+    name: prepare
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    outputs:
+      tag: ${{ steps.tag.outputs.tag }}
+      version: ${{ steps.tag.outputs.version }}
+
+    steps:
+      - name: Checkout master
+        uses: actions/checkout@v4
+        with:
+          ref: master
+          fetch-depth: 0
+
+      - name: Resolve latest release tag
+        id: tag
+        run: |
+          set -euo pipefail
+          git fetch --tags --force
+          latest_tag="$(
+            git tag -l 'v[0-9]*.[0-9]*.[0-9]*' --sort=-v:refname | head -n 1
+          )"
+          if [[ -z "${latest_tag}" ]]; then
+            echo "No stable semver tag found (expected vX.Y.Z)."
+            exit 1
+          fi
+          echo "tag=${latest_tag}" >> "$GITHUB_OUTPUT"
+          echo "version=${latest_tag#v}" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout latest tag
+        run: |
+          set -euo pipefail
+          git checkout "${{ steps.tag.outputs.tag }}"
+
+      - name: Install xmlstarlet
+        run: sudo apt-get update && sudo apt-get install -y xmlstarlet
+
+      - name: Validate pom.xml matches tag
+        run: |
+          set -euo pipefail
+          tag="${{ steps.tag.outputs.tag }}"
+          tag_version="${tag#v}"
+          pom_version="$({
+            xmlstarlet sel -t \
+              -v "/*[local-name()='project']/*[local-name()='version']" \
+              pom.xml
+          } | tail -n 1)"
+          if [[ "${pom_version}" != "${tag_version}" ]]; then
+            echo "pom.xml version (${pom_version})"
+            echo "does not match tag (${tag_version})"
+            exit 1
+          fi
+
+  package-ui:
+    name: package-ui-${{ matrix.os_label }}
+    needs: prepare
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 45
+    env:
+      GITHUB_ACTOR: ${{ github.actor }}
+      PACKAGES_TOKEN: ${{ secrets.PACKAGES_TOKEN }}
+      TAG: ${{ needs.prepare.outputs.tag }}
+      VERSION: ${{ needs.prepare.outputs.version }}
+      MAIN_CLASS: com.github.idelstak.friction.ui.FrictionUi
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            os_label: linux
+            archive_ext: tar.gz
+          - os: windows-latest
+            os_label: windows
+            archive_ext: zip
+          - os: macos-latest
+            os_label: macos
+            archive_ext: tar.gz
+
+    steps:
+      - name: Checkout release tag
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.prepare.outputs.tag }}
+          fetch-depth: 0
+
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '25'
+          cache: maven
+          server-id: github
+          server-username: GITHUB_ACTOR
+          server-password: PACKAGES_TOKEN
+
+      - name: Build non-shaded jar + libs
+        run: mvn -B -ntp -DskipTests package
+
+      - name: Build jpackage app-image (Linux/macOS)
+        if: runner.os != 'Windows'
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p packaging/out
+          jpackage \
+            --type app-image \
+            --name friction-ui \
+            --input target \
+            --main-jar "friction-ui-${VERSION}.jar" \
+            --main-class "${MAIN_CLASS}" \
+            --dest packaging/out
+
+      - name: Build jpackage app-image (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          New-Item -ItemType Directory -Path packaging/out -Force | Out-Null
+          jpackage `
+            --type app-image `
+            --name friction-ui `
+            --input target `
+            --main-jar "friction-ui-$env:VERSION.jar" `
+            --main-class "$env:MAIN_CLASS" `
+            --dest packaging/out
+
+      - name: Archive app-image (Linux/macOS)
+        if: runner.os != 'Windows'
+        id: archive_unix
+        shell: bash
+        run: |
+          set -euo pipefail
+          suffix="${{ matrix.os_label }}-app-image.tar.gz"
+          archive="friction-ui-${VERSION}-${suffix}"
+          tar -C packaging/out -czf "$archive" friction-ui
+          echo "archive=$archive" >> "$GITHUB_OUTPUT"
+
+      - name: Archive app-image (Windows)
+        if: runner.os == 'Windows'
+        id: archive_windows
+        shell: pwsh
+        run: |
+          $archive = (
+            "friction-ui-$env:VERSION-${{ matrix.os_label }}-app-image.zip"
+          )
+          Compress-Archive `
+            -Path "packaging/out/friction-ui" `
+            -DestinationPath $archive `
+            -Force
+          "archive=$archive" | Out-File `
+            -FilePath $env:GITHUB_OUTPUT `
+            -Append `
+            -Encoding utf8
+
+      - name: Create non-shaded jar + libs archive (Linux only)
+        if: runner.os == 'Linux'
+        id: jar_dist
+        shell: bash
+        run: |
+          set -euo pipefail
+          jar="target/friction-ui-${VERSION}.jar"
+          if [[ ! -f "$jar" ]]; then
+            echo "Expected jar not found: $jar"
+            exit 1
+          fi
+          if [[ ! -d target/libs ]]; then
+            echo "Expected libs directory not found: target/libs"
+            exit 1
+          fi
+          staging="release/friction-ui-${VERSION}"
+          mkdir -p "$staging/libs"
+          cp "$jar" "$staging/"
+          cp -R target/libs/. "$staging/libs/"
+          archive="friction-ui-${VERSION}-jar-libs.tar.gz"
+          tar -C release -czf "$archive" "friction-ui-${VERSION}"
+          echo "archive=$archive" >> "$GITHUB_OUTPUT"
+
+      - name: Upload release assets (Linux)
+        if: runner.os == 'Linux'
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ env.TAG }}
+          files: |
+            ${{ steps.archive_unix.outputs.archive }}
+            ${{ steps.jar_dist.outputs.archive }}
+
+      - name: Upload release assets (macOS)
+        if: runner.os == 'macOS'
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ env.TAG }}
+          files: |
+            ${{ steps.archive_unix.outputs.archive }}
+
+      - name: Upload release assets (Windows)
+        if: runner.os == 'Windows'
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ env.TAG }}
+          files: |
+            ${{ steps.archive_windows.outputs.archive }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,222 @@
+---
+name: Release
+
+'on':
+  push:
+    branches:
+      - master
+
+permissions:
+  contents: write
+  pull-requests: read
+
+concurrency:
+  group: release-master
+  cancel-in-progress: false
+
+jobs:
+  release:
+    name: release
+    if: github.actor != 'github-actions[bot]'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Resolve version bump from PR labels
+        id: version
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const sha = context.sha;
+            let pr = null;
+
+            const associated = await github.rest.repos
+              .listPullRequestsAssociatedWithCommit({
+                owner,
+                repo,
+                commit_sha: sha,
+              });
+            if (associated.data.length) {
+              const mergedPr = associated.data.find((item) => item.merged_at);
+              pr = mergedPr || associated.data[0];
+            }
+
+            if (!pr) {
+              const headMessage = context.payload.head_commit?.message || "";
+              const match = headMessage.match(/#(\d+)/);
+              if (match) {
+                const fetched = await github.rest.pulls.get({
+                  owner,
+                  repo,
+                  pull_number: Number(match[1]),
+                });
+                if (fetched.data.merged_at) {
+                  pr = fetched.data;
+                }
+              }
+            }
+
+            if (!pr) {
+              core.setFailed(`Unable to resolve merged PR for commit ${sha}.`);
+              return;
+            }
+
+            const labels = pr.labels.map((label) => label.name);
+            const impactLabels = [
+              "version:major",
+              "version:minor",
+              "version:patch",
+            ];
+            const prereleaseLabels = [
+              "version:alpha",
+              "version:beta",
+              "version:rc",
+            ];
+
+            const impact = impactLabels.filter(
+              (label) => labels.includes(label)
+            );
+            const prerelease = prereleaseLabels.filter(
+              (label) => labels.includes(label)
+            );
+
+            if (impact.length !== 1) {
+              core.setFailed(
+                "Expected exactly one impact label: " + impactLabels.join(", ")
+              );
+              return;
+            }
+            if (prerelease.length > 1) {
+              core.setFailed(
+                "Expected at most one prerelease label: " +
+                prereleaseLabels.join(", ")
+              );
+              return;
+            }
+
+            const tagResp = await github.rest.repos.listTags({
+              owner,
+              repo,
+              per_page: 100,
+            });
+            const semverTag = /^v(\d+)\.(\d+)\.(\d+)$/;
+            const stableTags = tagResp.data
+              .map((tag) => tag.name)
+              .filter((name) => semverTag.test(name));
+
+            const previousTag = stableTags[0] || "v0.0.0";
+            const matchVersion = previousTag.match(semverTag);
+
+            let major = Number(matchVersion?.[1] || 0);
+            let minor = Number(matchVersion?.[2] || 0);
+            let patch = Number(matchVersion?.[3] || 0);
+
+            if (impact[0] === "version:major") {
+              major += 1;
+              minor = 0;
+              patch = 0;
+            } else if (impact[0] === "version:minor") {
+              minor += 1;
+              patch = 0;
+            } else {
+              patch += 1;
+            }
+
+            let nextVersion = `${major}.${minor}.${patch}`;
+            if (prerelease.length === 1) {
+              const stage = prerelease[0].split(":")[1];
+              nextVersion = `${nextVersion}-${stage}.1`;
+            }
+
+            const nextTag = `v${nextVersion}`;
+            core.info(`PR #${pr.number} labels: ${labels.join(", ")}`);
+            core.info(`Previous tag: ${previousTag}`);
+            core.info(`Next version: ${nextVersion}`);
+
+            core.setOutput("pr_number", String(pr.number));
+            core.setOutput("next_version", nextVersion);
+            core.setOutput("next_tag", nextTag);
+            core.setOutput("prerelease", String(prerelease.length === 1));
+
+      - name: Set release version in pom.xml
+        run: |
+          set -euo pipefail
+          mvn -B -ntp versions:set \
+            -DnewVersion="${{ steps.version.outputs.next_version }}" \
+            -DgenerateBackupPoms=false
+
+      - name: Commit version bump
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email \
+            "41898282+github-actions[bot]@users.noreply.github.com"
+          git add pom.xml
+          next_version="${{ steps.version.outputs.next_version }}"
+          commit_msg="chore: bump version to ${next_version}"
+          git commit -m "${commit_msg}" || {
+            echo "No version change to commit"
+            exit 0
+          }
+          git push origin HEAD:master
+
+      - name: Create and push tag
+        run: |
+          set -euo pipefail
+          tag="${{ steps.version.outputs.next_tag }}"
+          if git rev-parse "$tag" >/dev/null 2>&1; then
+            echo "Tag $tag already exists; skipping"
+            exit 0
+          fi
+          git tag "$tag"
+          git push origin "$tag"
+
+      - name: Generate changelog
+        id: changelog
+        uses: actions/github-script@v7
+        env:
+          PR_NUMBER: ${{ steps.version.outputs.pr_number }}
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const prNumber = process.env.PR_NUMBER;
+            const prResp = await github.rest.pulls.get({
+              owner,
+              repo,
+              pull_number: Number(prNumber),
+            });
+            const pr = prResp.data;
+
+            const cleanedBody = (pr.body || "")
+              .replace(/<!--[\s\S]*?-->/g, "")
+              .trim();
+
+            const lines = [];
+            lines.push("# Changelog");
+            lines.push("");
+            lines.push(`#${pr.number} ${pr.title}`);
+            lines.push("");
+            if (cleanedBody.length) {
+              lines.push(cleanedBody);
+            } else {
+              lines.push("");
+            }
+
+            core.setOutput("body", lines.join("\n"));
+
+      - name: Create GitHub Release notes
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ steps.version.outputs.next_tag }}
+          name: ${{ steps.version.outputs.next_tag }}
+          body: ${{ steps.changelog.outputs.body }}
+          target_commitish: master
+          prerelease: ${{ steps.version.outputs.prerelease }}

--- a/docs/README.md
+++ b/docs/README.md
@@ -25,3 +25,4 @@ UI-owned docs in this folder cover:
 - [Read Model to UI State Mapping](./READ_MODEL_TO_UI_STATE_MAPPING.md)
 - [SPI Consumption and Effects Wiring](./SPI_EFFECTS_WIRING.md)
 - [Package Consumption (core + adapters)](./PACKAGE_CONSUMPTION.md)
+- [Release Packaging](./RELEASE_PACKAGING.md)

--- a/docs/RELEASE_PACKAGING.md
+++ b/docs/RELEASE_PACKAGING.md
@@ -1,0 +1,55 @@
+# Release Packaging
+
+`friction-ui` release output is non-shaded and consists of:
+
+- `friction-ui-<version>.jar`
+- runtime dependencies in `libs/`
+
+## Packaging Model
+
+`pom.xml` uses:
+
+- `maven-jar-plugin` to build a non-shaded jar
+- manifest entries:
+  - `Main-Class: com.github.idelstak.friction.ui.FrictionUi`
+  - classpath enabled with `libs/` prefix
+- `maven-dependency-plugin` to copy runtime dependencies to `target/libs/`
+
+## Runtime Execution
+
+From packaged output directory:
+
+```bash
+java -cp "friction-ui-<version>.jar:libs/*" com.github.idelstak.friction.ui.FrictionUi
+```
+
+## Release Workflow Model
+
+- `release.yml`
+  - push to `master`
+  - resolves semver bump from PR labels
+  - updates `pom.xml` version
+  - commits bump, tags release, creates GitHub release notes
+  - changelog format:
+    - `# Changelog`
+    - `#<PR_NUMBER> <PR_TITLE>`
+    - cleaned PR body
+
+- `publish-ui.yml`
+  - runs after successful `Release`
+  - checks out latest semver tag
+  - validates tag version matches `pom.xml`
+  - runs `mvn package`
+  - builds `jpackage` app-image artifacts on:
+    - Linux
+    - Windows
+    - macOS
+  - uploads release assets:
+    - `friction-ui-<version>-linux-app-image.tar.gz`
+    - `friction-ui-<version>-windows-app-image.zip`
+    - `friction-ui-<version>-macos-app-image.tar.gz`
+    - `friction-ui-<version>-jar-libs.tar.gz` (non-shaded jar + `libs/`, Linux job)
+
+## Version Bump Notes
+
+Version bump behavior follows the same PR-label semver pattern used in sibling repos.

--- a/docs/VERSIONING.md
+++ b/docs/VERSIONING.md
@@ -13,3 +13,26 @@ This repo follows that policy for release labeling and pre-release staging.
 - `friction.adapters.version`
 
 Update and adoption checklist is documented in `docs/PACKAGE_CONSUMPTION.md`.
+
+## Release Version Bump
+
+`friction-ui` release flow mirrors sibling repos:
+
+- resolve merged PR labels
+- compute next semantic version
+- update `pom.xml`
+- commit bump and create tag
+
+## Changelog Format
+
+Release notes are generated from current PR only:
+
+- `# Changelog`
+- `#<PR_NUMBER> <PR_TITLE>`
+- cleaned PR body
+
+No historical merged-PR aggregation is included.
+
+## Release Packaging
+
+Packaging model is documented in `docs/RELEASE_PACKAGING.md`.

--- a/docs/WORKFLOW_DEV.md
+++ b/docs/WORKFLOW_DEV.md
@@ -83,8 +83,36 @@ Ensure workflow checks align with repo release policy:
 `friction-core` is resolved transitively.
 
 - CI token: `secrets.PACKAGES_TOKEN` (package read access).
-- CI writes Maven settings for server id `github`.
+- CI configures Maven server id `github` via `actions/setup-java`.
 - Dependency pin and upgrade policy: `docs/PACKAGE_CONSUMPTION.md`.
+
+## Release and Artifact Workflows
+
+- `release.yml` (push to `master`):
+  - resolves semver bump from PR labels
+  - bumps `pom.xml` version
+  - commits bump, tags, and creates GitHub release notes
+  - changelog is generated from current PR only:
+    - `# Changelog`
+    - `#<PR_NUMBER> <PR_TITLE>`
+    - cleaned PR body
+- `publish-ui.yml` (`workflow_run` on successful `Release`):
+  - checks out latest semver tag
+  - validates tag/pom version match
+  - builds non-shaded jar + `libs/` layout
+  - builds `jpackage` app-image artifacts on Linux/Windows/macOS
+  - uploads cross-platform app-image archives to GitHub Release
+  - uploads non-shaded jar + `libs/` distribution archive
+
+Packaging details: `docs/RELEASE_PACKAGING.md`.
+
+## Artifact Retention Policy
+
+- `publish-ui.yml` attaches release outputs directly to GitHub Releases.
+- It does not use `actions/upload-artifact`, so no temporary artifact retention
+  window is configured there.
+- If temporary CI artifacts are introduced later, set explicit short retention
+  (`retention-days: 1` or similarly minimal).
 
 ## Notes
 

--- a/pom.xml
+++ b/pom.xml
@@ -25,4 +25,38 @@
             <url>https://maven.pkg.github.com/idelstak/friction-adapters</url>
         </repository>
     </repositories>
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>3.4.2</version>
+                <configuration>
+                    <archive>
+                        <manifest>
+                            <mainClass>com.github.idelstak.friction.ui.FrictionUi</mainClass>
+                            <addClasspath>true</addClasspath>
+                            <classpathPrefix>libs/</classpathPrefix>
+                        </manifest>
+                    </archive>
+                </configuration>
+            </plugin>
+            <plugin>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <version>3.10.0</version>
+                <executions>
+                    <execution>
+                        <id>copy-runtime-dependencies</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>copy-dependencies</goal>
+                        </goals>
+                        <configuration>
+                            <includeScope>runtime</includeScope>
+                            <outputDirectory>${project.build.directory}/libs</outputDirectory>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 </project>


### PR DESCRIPTION
This change introduces a full release path for `friction-ui` aligned with the established semver workflow used in sibling repos. A new `release.yml` resolves version labels from the merged PR, computes the next version, updates `pom.xml`, commits the bump, tags the release, and generates changelog notes from the current PR only using the standard format.

Packaging is now explicitly non-shaded in Maven. The build uses `maven-jar-plugin` to set `Main-Class` and classpath metadata with `libs/` prefix, and `maven-dependency-plugin` to copy runtime dependencies into `target/libs` for the external classpath distribution model.

A new `publish-ui.yml` workflow now runs after successful release and builds platform-specific `jpackage` app-image artifacts on Linux, Windows, and macOS. It validates tag-to-pom version consistency with `xmlstarlet`, publishes OS-specific release assets, and also uploads a Linux jar+libs distribution archive for the non-shaded runtime layout.

Documentation is updated to match the implemented behavior in `docs/RELEASE_PACKAGING.md`, `docs/WORKFLOW_DEV.md`, `docs/VERSIONING.md`, and `docs/README.md`, including release flow, changelog contract, artifact outputs, and operational usage.