### PR TITLE
Automate UI release packaging and reduce CI duplicates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,10 @@ permissions:
   contents: read
   packages: read
 
+concurrency:
+  group: ci-pr-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build-and-test:
     name: build-and-test

--- a/docs/README.md
+++ b/docs/README.md
@@ -26,3 +26,4 @@ UI-owned docs in this folder cover:
 - [SPI Consumption and Effects Wiring](./SPI_EFFECTS_WIRING.md)
 - [Package Consumption (core + adapters)](./PACKAGE_CONSUMPTION.md)
 - [Release Packaging](./RELEASE_PACKAGING.md)
+- [Workflow Development](./WORKFLOW_DEV.md)

--- a/docs/WORKFLOW_DEV.md
+++ b/docs/WORKFLOW_DEV.md
@@ -77,6 +77,19 @@ Ensure workflow checks align with repo release policy:
   - `version-label-check`
 - Branch protection should require both checks.
 
+## CI Concurrency
+
+`ci.yml` is configured to cancel older in-progress runs for the same PR.
+
+- Concurrency group:
+  - `ci-pr-${{ github.event.pull_request.number || github.ref }}`
+- Behavior:
+  - when new commits/label events trigger CI on the same PR, older runs are
+    canceled and only the latest run continues
+- Purpose:
+  - reduce duplicate concurrent runs from multiple PR event triggers
+  - keep check results focused on the most recent PR state
+
 ## Package Dependency Resolution
 
 `friction-ui` consumes published `friction-adapters` directly in CI.


### PR DESCRIPTION
This change adds a full release path for `friction-ui` aligned with sibling repos by introducing `release.yml` for semantic version bumping, tag creation, and current-PR changelog generation. The changelog format now follows the shared pattern and avoids historical PR aggregation noise.

Packaging is now explicitly non-shaded and reproducible. Maven is configured to generate a runnable jar with manifest main class and classpath prefix, and to copy runtime dependencies into `target/libs`. Release publishing is expanded with `publish-ui.yml`, which validates tag-to-pom version, builds `jpackage` app-image artifacts on Linux, Windows, and macOS, and uploads release assets including a jar+libs distribution archive.

CI behavior is also improved by adding workflow concurrency with in-progress cancellation, so only the latest run per PR remains active when multiple events fire close together. This reduces redundant compute and noisy parallel CI results without changing required check names.

Documentation is updated across release packaging, workflow development, versioning, and docs index pages to reflect the implemented flow, platform-specific packaging behavior, artifact expectations, and retention policy notes.